### PR TITLE
Add option to encode JSON hash to UTF-8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: perl
 
 perl:
    - "blead"
+   - "5.22"
    - "5.20"
    - "5.18"
    - "5.16"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: perl
 
 perl:
-   - "blead"
+   - "5.24"
    - "5.22"
    - "5.20"
    - "5.18"

--- a/README.md
+++ b/README.md
@@ -29,17 +29,17 @@ Example configuration:
 
     log4perl.appender.Test.layout.prefix = @cee:
 
-
     # Include the data in the Log::Log4perl::MDC hash (optional)
     log4perl.appender.Test.layout.include_mdc = 1
 
     # Use this field name for MDC data (else MDC data is placed at top level)
     log4perl.appender.Test.layout.name_for_mdc = mdc
 
-
     # Use canonical order for hash keys (optional)
-
     log4perl.appender.Test.layout.canonical = 1
+
+	# Encode the JSON hash to UTF-8
+	log4perl.appender.Test.layout.utf8 = 1
 
 # DESCRIPTION
 
@@ -49,7 +49,7 @@ hash.
 
 The JSON hash is ASCII encoded, with no newlines or other whitespace,
 and is suitable for output, via Log::Log4perl appenders, to files and
-syslog etc.
+syslog etc. The JSON hash can, optionally, be UTF-8 encoded.
 
 Contextual data in the Log::Log4perl::MDC hash can be included.
 

--- a/lib/Log/Log4perl/Layout/JSON.pm
+++ b/lib/Log/Log4perl/Layout/JSON.pm
@@ -105,6 +105,10 @@ field removed.
 
 In future this rather dumb logic will be replaced by something smarter.
 
+=head2 utf8
+
+Switch JSON encoding from ASCII to UTF-8.
+
 =head2 EXAMPLE USING Log::Log4perl::MDC
 
     local Log::Log4perl::MDC->get_context->{request} = {
@@ -236,6 +240,12 @@ sub BUILD { ## no critic (RequireArgUnpacking)
     }
 
     $self->field(delete $args->{field}) if $args->{field};
+
+	# Optionally override encoding from ascii to utf8
+	if (my $arg = $args->{utf8}) {
+		delete $args->{utf8};
+	    $self->codec( $self->codec->ascii(0)->utf8(1) );
+    }
 
     for my $arg_name (qw(
         canonical prefix include_mdc name_for_mdc max_json_length_kb


### PR DESCRIPTION
Add an option to change the JSON encoding to UTF-8 and a, very basic, test for this.
